### PR TITLE
* Fix displaying CP fail reasons

### DIFF
--- a/gateways/cp/js/leyka.cp.js
+++ b/gateways/cp/js/leyka.cp.js
@@ -100,7 +100,7 @@ jQuery(document).ready(function($){
                 $errors.html('').hide();
 
             }, function(reason, options){ // fail callback
-                addError($errors, leyka.cp_donation_failure_reasons[reason]);
+                addError($errors, leyka.cp_donation_failure_reasons[reason] || reason);
             });
 
             if($form.hasClass('leyka-revo-form')) {


### PR DESCRIPTION
`widget.charge` передает в onFail-обработчик в `reason` в том числе локализованный текст, например, `"Авторизация не пройдена"`. Тогда как `cp_donation_failure_reasons` содержит единственный ключ `"User has cancelled"` для ситуации, когда окно виджета закрыто пользователем без заполнения форм.
В итоге при "ошибках", отличных от закрытия виджета, показывается пустой блок ошибки.
А можно бы и выводить `reason` как есть, если для неё отсутствует кастомный перевод в словаре.