### PR TITLE
* Scroll error block to viewport center

### DIFF
--- a/gateways/cp/js/leyka.cp.js
+++ b/gateways/cp/js/leyka.cp.js
@@ -5,8 +5,11 @@ jQuery(document).ready(function($){
         function addError($errors_block, error_html) {
 
             $errors_block.html(error_html).show();
-            $('html, body').animate({ // 35px is a height of the WP admin bar (just in case)
-                scrollTop: $errors_block.offset().top - 35
+
+            // Center the error block in the viewport
+            $('html, body').animate({
+                scrollTop: $errors_block.offset().top -
+                    ($(window).height() - $errors_block.outerHeight()) / 2
             }, 250);
 
         }

--- a/gateways/paypal/js/leyka.paypal.js
+++ b/gateways/paypal/js/leyka.paypal.js
@@ -8,8 +8,11 @@
 	function addError($errors_block, error_html) {
 
 		$errors_block.html(error_html).show();
-		$('html, body').animate({ // 35px is a height of the WP admin bar (just in case)
-			scrollTop: $errors_block.offset().top - 35
+
+		// Center the error block in the viewport
+		$('html, body').animate({
+			scrollTop: $errors_block.offset().top -
+				($(window).height() - $errors_block.outerHeight()) / 2
 		}, 250);
 
 	}


### PR DESCRIPTION
Позиционировать блок ошибки по центру вьюпорта вместо верха с отступом для админ-панели WordPress. Лучше тем, что
* теперь блок ошибки не попадает ПОД собственный фиксированный хедер сайтов, который больше по высоте, чем админ-панель WP
* внимание пользователей ближе к центру вьюпорта нежели к верхнему краю