### PR TITLE
FIX: Проверка условия для применения фильтра

### DIFF
--- a/inc/leyka-class-campaign.php
+++ b/inc/leyka-class-campaign.php
@@ -121,7 +121,7 @@ class Leyka_Campaign_Management extends Leyka_Singleton {
      */
     public function do_filtering(WP_Query $query) {
 
-        if( !is_admin() || !$query->is_main_query() || get_current_screen()->id !== 'edit-'.self::$post_type ) {
+        if( !$query->is_main_query() || !get_current_screen() || get_current_screen()->id !== 'edit-'.self::$post_type ) {
             return;
         }
 

--- a/inc/leyka-class-donation.php
+++ b/inc/leyka-class-donation.php
@@ -254,8 +254,7 @@ class Leyka_Donation_Management {
 
     public function do_filtering(WP_Query $query) {
 
-        if(is_admin() && $query->is_main_query() && get_current_screen()->id == 'edit-'.self::$post_type) {
-
+        if($query->is_main_query() && get_current_screen() && get_current_screen()->id == 'edit-'.self::$post_type) {
             $meta_query = array('relation' => 'AND');
 
             if( !empty($_REQUEST['campaign']) ) {


### PR DESCRIPTION
В логах скапливаются ошибки:
```
PHP Notice:  Trying to get property 'id' of non-object in ...\wp-content\plugins\leyka\inc\leyka-class-campaign.php on line 124
PHP Notice:  Trying to get property 'id' of non-object in ...\wp-content\plugins\leyka\inc\leyka-class-donation.php on line 257
```
Ошибки генерируются при ajax запросах в админке (например при heartbeat-запросах), потому что функция ``get_current_screen()`` при ajax запросе возвращает ``null``, а не объект класса ``WP_Screen``.

Взамен функции ``is_admin``, которая возвращает ``true`` и при ajax запросах, использую проверку на возвращаемое значение функцией ``get_current_screen()``, которая даст результат только на страницах админки.