### PR TITLE
Check the CloudPayments notification status before cancelling the donation

### DIFF
--- a/gateways/cp/leyka-class-cp-gateway.php
+++ b/gateways/cp/leyka-class-cp-gateway.php
@@ -398,10 +398,14 @@ class Leyka_CP_Gateway extends Leyka_Gateway {
 
                     if($init_recurring_donation && $init_recurring_donation->recurring_is_active) {
 
-                        $init_recurring_donation->recurring_is_active = false;
+                        if(!empty($_POST['Status'])) {
 
-                        do_action('leyka_cp_cancel_recurring_subscription', $init_recurring_donation);
+                            if($_POST['Status'] == 'Cancelled' || $_POST['Status'] == 'Rejected' || $_POST['Status'] == 'Expired')  {
 
+                                $init_recurring_donation->recurring_is_active = false;
+                                do_action('leyka_cp_cancel_recurring_subscription', $init_recurring_donation);
+                            }
+                        }
                     }
 
                 }


### PR DESCRIPTION
Some CP notifications are about the subscription being cancelled but others are about failed transactions (which does not yet mean cancellation) or updates to the details (amount, date etc.) of the subscription.
This fix makes sure we check the status and only cancel the sub on our side if the appropriate status is found.