### PR TITLE
fix: The overlay opened when clicking on any anchor link

### DIFF
--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -1916,7 +1916,7 @@ window.LeykaPageMain.prototype = {
                         return false;
                     }
 
-                    let $_form = $('#' + form_id);
+                    let $_form = $('form#' + form_id);
                     
                     if($_form.length > 0) {
 


### PR DESCRIPTION
Попап форма открывалась при любом совпадении хеша и id на странице. 
Лучшее более жестко задать поиск нужно формы - классом, но не знаю, используется ли один класс на всех формах.