### PR TITLE
Fix the deprecated error on "Donation info" page in wp-admin ...

### DIFF
--- a/inc/donations/leyka-class-donations-management.php
+++ b/inc/donations/leyka-class-donations-management.php
@@ -1672,7 +1672,7 @@ class Leyka_Donation_Management extends Leyka_Singleton {
 
             <?php $gateway = leyka_get_gateway_by_id($donation->gateway_id);
             if($gateway && method_exists($gateway, 'display_donation_specific_data_fields')) { ?>
-                <div class="leyka-ddata-string"><?php echo wp_kses_post( $gateway->display_donation_specific_data_fields($donation) ); ?></div>
+                <div class="leyka-ddata-string"><?php $gateway->display_donation_specific_data_fields($donation) ?></div>
             <?php }?>
 
             <?php if ($donation->is_init_recurring_donation || $donation->init_recurring_donation_id) { ?>

--- a/inc/leyka-gateways-api.php
+++ b/inc/leyka-gateways-api.php
@@ -785,7 +785,11 @@ abstract class Leyka_Gateway extends Leyka_Singleton {
     public function gateway_redirect_page_content($pm_id, $donation_id) {
     }
 
-    /** Get gateway specific donation fields for an "add/edit donation" page ("donation data" metabox). */
+    /**
+     * Get gateway specific donation fields for an "add/edit donation" page ("donation data" metabox).
+     *
+     * @return void
+     */
     public function display_donation_specific_data_fields($donation = false) {
     }
 


### PR DESCRIPTION
error: `PHP Deprecated:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in .../wp-includes/kses.php on line 1805

\Leyka_Gateway::display_donation_specific_data_fields() method is void actually. It doesn't need nighter `echo` nor `wp_kses`.