### PR TITLE
Fix rewriting of Campaign->target_reaching_mailout_sent during changing Campaign->form_content_position (via Campaign->__set())

### DIFF
--- a/inc/leyka-class-campaign.php
+++ b/inc/leyka-class-campaign.php
@@ -2068,11 +2068,10 @@ class Leyka_Campaign {
         switch($field) {
             case 'form_content_position':
                 if(in_array($value, ['before-content', 'after-content'])) {
-
                     $this->_campaign_meta['form_content_position'] = $value;
                     update_post_meta($this->_id, 'form_content_position', $value);
-
                 }
+                break;
             case 'target_reaching_mailout_sent':
                 $this->_campaign_meta['target_reaching_mailout_sent'] = !!$value;
                 update_post_meta($this->_id, '_leyka_target_reaching_mailout_sent', !!$value);


### PR DESCRIPTION
It's an obvious bug (missing `break`).

Fortunately, the construction `$campaign->form_content_position = "<smth>";` isn't used in the plugin (and `Leyka_Campaign->__set()` isn't executed for `form_content_position`). But the bug can be reproduced in external code (extensions, etc.)

## Steps to reproduce
1. Create a new Campaign (on development environment of course)
2. Run WP-CLI: `wp shell`
3. Run the code below line by line

```php
$c = new \Leyka_Campaign(123123); // change to your campaign id

// setting "target_reaching_mailout_sent" to false
$c->target_reaching_mailout_sent = false;
$c->target_reaching_mailout_sent; // false

// changing "form_content_position" value
$c->form_content_position = 'after-content';
$c->form_content_position; // 'after-content'

// "target_reaching_mailout_sent" has been changed to true. It's a bug.
$c->target_reaching_mailout_sent; // true

```